### PR TITLE
Improvements on extract_from_xm

### DIFF
--- a/R/extract_feats.R
+++ b/R/extract_feats.R
@@ -20,23 +20,19 @@ extract_from_xm <- function(listName, feat = c("tissue", "sex", "genotype")) {
     # Check for allowed features
     feat <- match.arg(feat)
     # remove whitespaces from the string
-    listName <- gsub(" ", "", listName)
+    listName <- gsub(" ", "", listName, fixed = TRUE)
     # remove "/" symbol from the string
-    listName <- gsub("/", "", listName)
+    listName <- gsub("/", "", listName, fixed = TRUE)
     # Remove quotes and protection for them
-    listName <- gsub('\\\"', "", listName)
+    listName <- gsub('\\\"', "", listName, fixed = TRUE)
     # Split by line
-    listName <- strsplit(listName, "\n")
+    listName <- strsplit(listName, "\n", fixed = TRUE)
     # Look up for the features
     v <- vector("character", length(listName[[1]]))
     for (i in seq(listName[[1]])) {
         val <- listName[[1]][i]
-        # Skip if doesn't have key=value
-        if (!grepl("=", val)) {
-            next
-        }
         # Check for features
-        if (grepl(paste(feat, collapse = "|"), val)) {
+        if (grepl(feat, val, fixed = TRUE)) {
             v[i] <- gsub(".+=(.+)$", "\\1", val)
         }
     }

--- a/man/extract_from_xm.Rd
+++ b/man/extract_from_xm.Rd
@@ -4,16 +4,17 @@
 \alias{extract_from_xm}
 \title{Extract some features from an XM accession}
 \usage{
-extract_from_xm(listName, feat = "tissue")
+extract_from_xm(listName, feat = c("tissue", "sex", "genotype"))
 }
 \arguments{
 \item{listName}{a downloaded flat file from the nuccore NCBI database}
 
-\item{feat}{a feature to be extracted. Allowed features include "sex", "tissue" or "genotype"}
+\item{feat}{a feature to be extracted. Allowed features include "tissue",
+"sex", or "genotype". Default is tissue.}
 }
 \description{
-Parses an XM acession (Genbank format) and extract some features provided by
-the user.
+Parses an XM accession (Genbank format) and extract either sex, tissue or
+genotype.
 }
 \examples{
 xm <- "XM_020388824"


### PR DESCRIPTION
Some modifications to make the function more general (now it could be used to extract other features) and faster.

I'm not convinced of the name, as it doesn't really work with the xm, and was about to move  the call to 
 `mrna_gb <- rentrez::entrez_fetch(db = "nuccore", id = xm, rettype = "gp")` to inside the function, but that would make it slower to retrieve several features for the same xm, although, it could extract multiple features and values with a single call too. 